### PR TITLE
Add Github Actions workflow for macOS 64-bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,76 @@ env:
   PLUGIN_NAME: move-transition
 
 jobs:
+  macos64:
+    name: "macOS 64-bit"
+    runs-on: [macos-latest]
+    env:
+      QT_VERSION: 5.14.1
+      OSX_DEPS_VERSION: '2020-04-07'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: obsproject/obs-studio
+          submodules: 'recursive'
+      - name: "Checkout obs-move-transition"
+        uses: actions/checkout@v2
+        with:
+          path: plugins/${{ env.PLUGIN_NAME }}
+      - name: Fetch Git Tags
+        run: |
+          cd plugins/${{ env.PLUGIN_NAME }}
+          git fetch --prune --tags --unshallow
+      - name: 'Install prerequisites (Homebrew)'
+        shell: bash
+        run: |
+          cd plugins/${{ env.PLUGIN_NAME }}/CI/macos
+          brew bundle
+          cd -
+      - name: 'Install prerequisite: Pre-built dependencies'
+        shell: bash
+        run: |
+          curl -L -O https://github.com/obsproject/obs-deps/releases/download/${{ env.OSX_DEPS_VERSION }}/osx-deps-${{ env.OSX_DEPS_VERSION }}.tar.gz
+          tar -xf ./osx-deps-${{ env.OSX_DEPS_VERSION }}.tar.gz -C "/tmp"
+      - name: Configure
+        shell: bash
+        run: |
+          echo "add_subdirectory(${{ env.PLUGIN_NAME }})" >> plugins/CMakeLists.txt
+          mkdir ./build
+          cd ./build
+          cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DDepsPath="/tmp/obsdeps" -DQTDIR="/usr/local/Cellar/qt/${{ env.QT_VERSION }}" ..
+          cd -
+      - name: Build
+        shell: bash
+        run: |
+          set -e
+          cd ./build
+          make -j4
+          cd -
+      - name: 'Install prerequisite: Packages app'
+        if: success()
+        shell: bash
+        run: |
+          curl -L -O https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg
+          sudo installer -pkg ./Packages.pkg -target /
+      - name: Package
+        if: success()
+        shell: bash
+        run: |
+          cd plugins/${{ env.PLUGIN_NAME }}
+          FILE_DATE=$(date +%Y-%m-%d)
+          FILE_NAME=${{ env.PLUGIN_NAME }}-$FILE_DATE-${{ github.sha }}-macos.pkg
+          echo "::set-env name=FILE_NAME::${FILE_NAME}"
+          packagesbuild ./CI/macos/${{ env.PLUGIN_NAME }}.pkgproj
+          cd -
+          mkdir ./nightly
+          mv plugins/${{ env.PLUGIN_NAME }}/move-transition.pkg ./nightly/${FILE_NAME}
+      - name: Publish
+        if: success()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: '${{ env.FILE_NAME }}'
+          path: ./nightly/*.pkg
   win64:
     name: Windows 64-bit
     runs-on: [windows-latest]
@@ -54,15 +124,16 @@ jobs:
         if: success()
         run: |
           $env:FILE_DATE=(Get-Date -UFormat "%F")
-          $env:FILENAME="${{ env.PLUGIN_NAME }}-${env:FILE_DATE}-${{ github.sha }}-win64.zip"
-          robocopy .\build64\rundir\RelWithDebInfo\obs-plugins\64bit\ .\build\obs-plugins\64bit ${{ env.PLUGIN_NAME }}.* /E /XF .gitignore 
+          $env:FILE_NAME="${{ env.PLUGIN_NAME }}-${env:FILE_DATE}-${{ github.sha }}-win64.zip"
+          echo "::set-env name=FILE_NAME::${env:FILE_NAME}"
+          robocopy .\build64\rundir\RelWithDebInfo\obs-plugins\64bit\ .\build\obs-plugins\64bit ${{ env.PLUGIN_NAME }}.* /E /XF .gitignore
           robocopy .\build64\rundir\RelWithDebInfo\data\obs-plugins\${{ env.PLUGIN_NAME }}\ .\build\data\obs-plugins\${{ env.PLUGIN_NAME }}\ /E /XF .gitignore
-          7z a ${env:FILENAME} .\build\*
+          7z a ${env:FILE_NAME} .\build\*
       - name: Publish
         if: success()
         uses: actions/upload-artifact@v2-preview
         with:
-          name: '${{ env.FILENAME }}'
+          name: '${{ env.FILE_NAME }}'
           path: '*-win64.zip'
   win32:
     name: Windows 32-bit
@@ -108,13 +179,14 @@ jobs:
         if: success()
         run: |
           $env:FILE_DATE=(Get-Date -UFormat "%F")
-          $env:FILENAME="${{ env.PLUGIN_NAME }}-${env:FILE_DATE}-${{ github.sha }}-win32.zip"
+          $env:FILE_NAME="${{ env.PLUGIN_NAME }}-${env:FILE_DATE}-${{ github.sha }}-win32.zip"
+          echo "::set-env name=FILE_NAME::${env:FILE_NAME}"
           robocopy .\build32\rundir\RelWithDebInfo\obs-plugins\32bit\ .\build\obs-plugins\32bit ${{ env.PLUGIN_NAME }}.* /E /XF .gitignore
           robocopy .\build32\rundir\RelWithDebInfo\data\obs-plugins\${{ env.PLUGIN_NAME }}\ .\build\data\obs-plugins\${{ env.PLUGIN_NAME }}\ /E /XF .gitignore
-          7z a ${env:FILENAME} .\build\*
+          7z a ${env:FILE_NAME} .\build\*
       - name: Publish
         if: success()
         uses: actions/upload-artifact@v2-preview
         with:
-          name: '${{ env.FILENAME }}'
+          name: '${{ env.FILE_NAME }}'
           path: '*-win32.zip'

--- a/CI/macos/Brewfile
+++ b/CI/macos/Brewfile
@@ -1,0 +1,6 @@
+brew "jack"
+brew "speexdsp"
+brew "cmake"
+brew "freetype"
+brew "fdk-aac"
+brew "https://gist.githubusercontent.com/DDRBoxman/9c7a2b08933166f4b61ed9a44b242609/raw/ef4de6c587c6bd7f50210eccd5bd51ff08e6de13/qt.rb"

--- a/CI/macos/move-transition.pkgproj
+++ b/CI/macos/move-transition.pkgproj
@@ -36,7 +36,7 @@
 																		<key>GID</key>
 																		<integer>80</integer>
 																		<key>PATH</key>
-																		<string>../../../../build/plugins/obs-move-transition/move-transition.so</string>
+																		<string>../../../../build/plugins/move-transition/move-transition.so</string>
 																		<key>PATH_TYPE</key>
 																		<integer>3</integer>
 																		<key>PERMISSIONS</key>
@@ -550,7 +550,7 @@
 			<key>FOLLOW_SYMBOLIC_LINKS</key>
 			<false/>
 			<key>IDENTIFIER</key>
-			<string>com.exeldro.obs-move-transition</string>
+			<string>com.exeldro.move-transition</string>
 			<key>LOCATION</key>
 			<integer>0</integer>
 			<key>NAME</key>
@@ -763,7 +763,7 @@
 				</dict>
 			</array>
 			<key>NAME</key>
-			<string>obs-move-transition</string>
+			<string>move-transition</string>
 			<key>PAYLOAD_ONLY</key>
 			<false/>
 		</dict>


### PR DESCRIPTION
Important note on this PR: While the GitHub Actions workflow itself succeeds (and artifacts are created for Win32, Win64 and macOS64), the macOS plugin currently crashes OBS at launch. The issue also happens when built from current sources, so it's probably unrelated to the CI build process:

```
0   libsystem_c.dylib             	0x00007fff6de5ffca __chk_fail_overflow.cold.1 + 16
1   libsystem_c.dylib             	0x00007fff6de5d214 __chk_fail_overflow + 9
2   libsystem_c.dylib             	0x00007fff6de5d848 __memcpy_chk + 18
3   libobs.0.dylib                	0x00000001095fb764 obs_register_source_s + 292
4   move-transition.so            	0x00000000154ec435 obs_module_load + 21
5   libobs.0.dylib                	0x00000001095fa4f3 obs_init_module + 83
6   libobs.0.dylib                	0x00000001095fb380 load_all_callback + 64
7   libobs.0.dylib                	0x00000001095fb299 obs_find_modules + 2153
8   libobs.0.dylib                	0x00000001095faa13 obs_load_all_modules + 35
9   com.obsproject.obs-studio     	0x0000000106dd7a87 OBSBasic::OBSInit() + 775
10  com.obsproject.obs-studio     	0x0000000106db7aab OBSApp::OBSInit() + 491
11  com.obsproject.obs-studio     	0x0000000106dba549 main + 5209
12  libdyld.dylib                 	0x00007fff6dd90cc9 start + 1
```

Another important note: Without notarization (which would require setting up an Apple Developer account and store certificates as well as account credentials as CI secrets) the package installer will be blocked by default on macOS.

People will need to right-click the `.pkg` file in Finder and select to "Open" the package installer, then click "Open" again to confirm.