### PR TITLE
Change X and Y positions to allow up to 3 decimal places instead of 1

### DIFF
--- a/move-source-filter.c
+++ b/move-source-filter.c
@@ -669,7 +669,7 @@ void update_transform_text(struct move_source_info *move_source,
 		    OBS_BOUNDS_NONE) {
 			snprintf(
 				transform_text, 500,
-				"pos: x%c%.1f y%c%.1f rot:%c%.1f scale: x%c%.3f y%c%.3f crop: l%c%d t%c%d r%c%d b%c%d",
+				"pos: x%c%.3f y%c%.3f rot:%c%.1f scale: x%c%.3f y%c%.3f crop: l%c%d t%c%d r%c%d b%c%d",
 				obs_data_get_char(pos, "x_sign"),
 				obs_data_get_double(pos, "x"),
 				obs_data_get_char(pos, "y_sign"),
@@ -691,7 +691,7 @@ void update_transform_text(struct move_source_info *move_source,
 		} else {
 			snprintf(
 				transform_text, 500,
-				"pos: x%c%.1f y%c%.1f rot:%c%.1f bounds: x%c%.3f y%c%.3f crop: l%c%d t%c%d r%c%d b%c%d",
+				"pos: x%c%.3f y%c%.3f rot:%c%.1f bounds: x%c%.3f y%c%.3f crop: l%c%d t%c%d r%c%d b%c%d",
 				obs_data_get_char(pos, "x_sign"),
 				obs_data_get_double(pos, "x"),
 				obs_data_get_char(pos, "y_sign"),
@@ -714,7 +714,7 @@ void update_transform_text(struct move_source_info *move_source,
 	} else {
 		snprintf(
 			transform_text, 500,
-			"pos: x%c%.1f y%c%.1f rot:%c%.1f scale: x%c%.3f y%c%.3f bounds: x%c%.3f y%c%.3f crop: l%c%d t%c%d r%c%d b%c%d",
+			"pos: x%c%.3f y%c%.3f rot:%c%.1f scale: x%c%.3f y%c%.3f bounds: x%c%.3f y%c%.3f crop: l%c%d t%c%d r%c%d b%c%d",
 			obs_data_get_char(pos, "x_sign"),
 			obs_data_get_double(pos, "x"),
 			obs_data_get_char(pos, "y_sign"),


### PR DESCRIPTION
_Fixes #149_ 

This addresses an issue I encountered where the X and Y position variables for the move source filter were limited to only 1 decimal place based on the original formatting added for those variables. The amount of decimal places I can change based on feedback if needed, but this should allow more flexibility on what people can do with the position changes.

I did test this against my original filters created and no data appears to have been lost with these changes. Please let me know if you'd like me to change anything!